### PR TITLE
Update pipeline_wan_fun_inpaint_audio.py

### DIFF
--- a/src/pipeline_wan_fun_inpaint_audio.py
+++ b/src/pipeline_wan_fun_inpaint_audio.py
@@ -278,7 +278,7 @@ class WanFunInpaintAudioPipeline(DiffusionPipeline):
         if prompt is not None:
             batch_size = len(prompt)
         else:
-            batch_size = prompt_embeds.shape[0]
+            batch_size = len(prompt_embeds) if isinstance(prompt_embeds, list) else prompt_embeds.shape[0]
 
         if prompt_embeds is None:
             prompt_embeds = self._get_t5_prompt_embeds(
@@ -555,7 +555,7 @@ class WanFunInpaintAudioPipeline(DiffusionPipeline):
         elif prompt is not None and isinstance(prompt, list):
             batch_size = len(prompt)
         else:
-            batch_size = prompt_embeds.shape[0]
+            batch_size = len(prompt_embeds) if isinstance(prompt_embeds, list) else prompt_embeds.shape[0]
 
         device = self._execution_device
         weight_dtype = self.text_encoder.dtype


### PR DESCRIPTION
类型问题

## Summary by Sourcery

Fix batch size calculation to support list-type prompt embeddings in pipeline_wan_fun_inpaint_audio.

Bug Fixes:
- Use len() for prompt_embeds when it’s a list instead of accessing shape, avoiding TypeError in encode_prompt
- Apply the same len()-based batch size logic for list-type prompt_embeds in the __call__ method